### PR TITLE
Replace Deprecated Variable Names

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,7 @@ end
 -- Define Rainbow_Ore_Block node
 minetest.register_node("rainbow_ore:rainbow_ore_block", {
 	description = "Rainbow Ore",
-	tile_images = {"rainbow_ore_block.png"},
+	tiles = {"rainbow_ore_block.png"},
 	groups = {stone=2, cracky=3},
 	drop = "rainbow_ore:rainbow_ore_block",
 	is_ground_content = true,
@@ -167,6 +167,6 @@ minetest.register_ore({
 	clust_scarcity = 17*17*17,
 	clust_num_ores = 3,
 	clust_size = 3,
-	height_min = -31000,
-	height_max = -200,
+	y_min = -31000,
+	y_max = -200,
 })

--- a/init.lua
+++ b/init.lua
@@ -34,6 +34,21 @@ minetest.register_craft({
 })
 
 
+local t_uses = {}
+local tool_wear_enabled = minetest.settings:get_bool("enable_tool_wear")
+if tool_wear_enabled == nil then
+	-- Default is enabled
+	tool_wear_enabled = true
+end
+
+if tool_wear_enabled then
+	t_uses.fifteen = 15
+	t_uses.twenty = 20
+else
+	t_uses.fifteen = 0
+	t_uses.twenty = 0
+end
+
 --Register Rainbow Pickaxe
 minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
 	description = "Rainbow Pickaxe",
@@ -42,7 +57,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
 		full_punch_interval = 0.9,
 		max_drop_level=3,
 		groupcaps={
-			cracky = {times={[1]=1.0, [2]=0.5, [3]=0.25}, uses=15, maxlevel=3},
+			cracky = {times={[1]=1.0, [2]=0.5, [3]=0.25}, uses=t_uses.fifteen, maxlevel=3},
 		},
 		damage_groups = {fleshy=5},
 	},
@@ -68,7 +83,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_axe", {
 		full_punch_interval = 0.9,
 		max_drop_level=3,
 		groupcaps={
-			choppy={times={[1]=1.05, [2]=0.45, [3]=0.25}, uses=15, maxlevel=3},
+			choppy={times={[1]=1.05, [2]=0.45, [3]=0.25}, uses=t_uses.fifteen, maxlevel=3},
 		},
 		damage_groups = {fleshy=7},
 	}
@@ -104,7 +119,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_shovel", {
 		full_punch_interval = 1.0,
 		max_drop_level=3,
 		groupcaps={
-			crumbly = {times={[1]=0.55, [2]=0.25, [3]=0.15}, uses=15, maxlevel=3},
+			crumbly = {times={[1]=0.55, [2]=0.25, [3]=0.15}, uses=t_uses.fifteen, maxlevel=3},
 		},
 		damage_groups = {fleshy=4},
 	},
@@ -130,7 +145,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_sword", {
 		full_punch_interval = 0.7,
 		max_drop_level=3,
 		groupcaps={
-			snappy={times={[1]=0.95, [2]=0.45, [3]=0.15}, uses=20, maxlevel=3},
+			snappy={times={[1]=0.95, [2]=0.45, [3]=0.15}, uses=t_uses.twenty, maxlevel=3},
 		},
 		damage_groups = {fleshy=8},
 	}


### PR DESCRIPTION
#### 60dc35e:
Replaced deprecated variable names:
- 'tiles' in place of 'tile_images'
- 'y_min' in place of 'height_min'
- 'y_max' in place of 'height_max'

#### 002b2e2:
Added [craft_guide](https://forum.minetest.net/viewtopic.php?t=2334) as an optional dependency.

#### 32210c1:
Created *.gitignore* file to ignore Eclipse project files (for developers using Eclipse environment).