### PR TITLE
Use setting 'enable_tool_wear' to enable/disable tools wearing/breaking

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -34,6 +34,21 @@ minetest.register_craft({
 })
 
 
+local t_uses = {}
+local tool_wear_enabled = minetest.settings:get_bool("enable_tool_wear")
+if tool_wear_enabled == nil then
+	-- Default is enabled
+	tool_wear_enabled = true
+end
+
+if tool_wear_enabled then
+	t_uses.fifteen = 15
+	t_uses.twenty = 20
+else
+	t_uses.fifteen = 0
+	t_uses.twenty = 0
+end
+
 --Register Rainbow Pickaxe
 minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
 	description = "Rainbow Pickaxe",
@@ -42,7 +57,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
 		full_punch_interval = 0.9,
 		max_drop_level=3,
 		groupcaps={
-			cracky = {times={[1]=1.0, [2]=0.5, [3]=0.25}, uses=15, maxlevel=3},
+			cracky = {times={[1]=1.0, [2]=0.5, [3]=0.25}, uses=t_uses.fifteen, maxlevel=3},
 		},
 		damage_groups = {fleshy=5},
 	},
@@ -68,7 +83,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_axe", {
 		full_punch_interval = 0.9,
 		max_drop_level=3,
 		groupcaps={
-			choppy={times={[1]=1.05, [2]=0.45, [3]=0.25}, uses=15, maxlevel=3},
+			choppy={times={[1]=1.05, [2]=0.45, [3]=0.25}, uses=t_uses.fifteen, maxlevel=3},
 		},
 		damage_groups = {fleshy=7},
 	}
@@ -104,7 +119,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_shovel", {
 		full_punch_interval = 1.0,
 		max_drop_level=3,
 		groupcaps={
-			crumbly = {times={[1]=0.55, [2]=0.25, [3]=0.15}, uses=15, maxlevel=3},
+			crumbly = {times={[1]=0.55, [2]=0.25, [3]=0.15}, uses=t_uses.fifteen, maxlevel=3},
 		},
 		damage_groups = {fleshy=4},
 	},
@@ -130,7 +145,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_sword", {
 		full_punch_interval = 0.7,
 		max_drop_level=3,
 		groupcaps={
-			snappy={times={[1]=0.95, [2]=0.45, [3]=0.15}, uses=20, maxlevel=3},
+			snappy={times={[1]=0.95, [2]=0.45, [3]=0.15}, uses=t_uses.twenty, maxlevel=3},
 		},
 		damage_groups = {fleshy=8},
 	}


### PR DESCRIPTION
- Default: true
- If 'false', tools will not wear or break when used for digging,
chopping, etc.