### PR TITLE
Bugfix crafting grid 4x4 to 3x3

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -53,9 +53,9 @@ minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
 minetest.register_craft({
 	output = "rainbow_ore:rainbow_ore_pickaxe",
 	recipe = {
-		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", ""},
-		{"", "default:stick", "", ""},
-		{"", "default:stick", "", ""}
+		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
+		{"", "default:stick", ""},
+		{"", "default:stick", ""}
 	}
 })
 
@@ -79,18 +79,18 @@ minetest.register_tool("rainbow_ore:rainbow_ore_axe", {
 minetest.register_craft({
 	output = "rainbow_ore:rainbow_ore_axe",
 	recipe = {
-		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "", ""},
-		{"rainbow_ore:rainbow_ore_ingot", "default:stick", "", ""},
-		{"", "default:stick", "", ""}
+		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", ""},
+		{"rainbow_ore:rainbow_ore_ingot", "default:stick", ""},
+		{"", "default:stick", ""}
 	}
 })
 
 minetest.register_craft({
 	output = "rainbow_ore:rainbow_ore_axe",
 	recipe = {
-		{"", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", ""},
-		{"", "default:stick", "rainbow_ore:rainbow_ore_ingot", ""},
-		{"", "default:stick", "", ""}
+		{"", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
+		{"", "default:stick", "rainbow_ore:rainbow_ore_ingot"},
+		{"", "default:stick", ""}
 	}
 })
 
@@ -115,9 +115,9 @@ minetest.register_tool("rainbow_ore:rainbow_ore_shovel", {
 minetest.register_craft({
 	output = "rainbow_ore:rainbow_ore_shovel",
 	recipe = {
-		{"", "rainbow_ore:rainbow_ore_ingot", "", ""},
-		{"", "default:stick", "", ""},
-		{"", "default:stick", "", ""}
+		{"", "rainbow_ore:rainbow_ore_ingot", ""},
+		{"", "default:stick", ""},
+		{"", "default:stick", ""}
 	}
 })
 
@@ -141,9 +141,9 @@ minetest.register_tool("rainbow_ore:rainbow_ore_sword", {
 minetest.register_craft({
 	output = "rainbow_ore:rainbow_ore_sword",
 	recipe = {
-		{"", "rainbow_ore:rainbow_ore_ingot", "", ""},
-		{"", "rainbow_ore:rainbow_ore_ingot", "", ""},
-		{"", "default:stick", "", ""}
+		{"", "rainbow_ore:rainbow_ore_ingot", ""},
+		{"", "rainbow_ore:rainbow_ore_ingot", ""},
+		{"", "default:stick", ""}
 	}
 })
 


### PR DESCRIPTION
The tools unneccessarily are defined for a 4x3 crafting grid. This change makes it a standard 3x3 crafting grid again.