### PR TITLE
Add Localization Support

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,0 @@
-default
-3d_armor?
-shields?

--- a/init.lua
+++ b/init.lua
@@ -1,17 +1,24 @@
 -- Rainbow_Ore Test Mod ----------- Copyright Robin Kuhn 2015
 
+rainbow_ore = {}
+rainbow_ore.modname = minetest.get_current_modname()
+rainbow_ore.modpath = minetest.get_modpath(rainbow_ore.modname)
+
 --Check for mods
 if minetest.get_modpath("3d_armor") then
-dofile(minetest.get_modpath("rainbow_ore").."/rainbow_armor.lua")
+dofile(rainbow_ore.modpath.."/rainbow_armor.lua")
 end
 
 if minetest.get_modpath("shields") then
-dofile(minetest.get_modpath("rainbow_ore").."/rainbow_shield.lua")
+dofile(rainbow_ore.modpath.."/rainbow_shield.lua")
 end
+
+
+local S = minetest.get_translator(rainbow_ore.modname)
 
 -- Define Rainbow_Ore_Block node
 minetest.register_node("rainbow_ore:rainbow_ore_block", {
-	description = "Rainbow Ore",
+	description = S("Rainbow Ore"),
 	tiles = {"rainbow_ore_block.png"},
 	groups = {stone=2, cracky=3},
 	drop = "rainbow_ore:rainbow_ore_block",
@@ -21,7 +28,7 @@ minetest.register_node("rainbow_ore:rainbow_ore_block", {
 
 --Define Rainbow_Ore_Ingot node
 minetest.register_craftitem("rainbow_ore:rainbow_ore_ingot", {
-	description = "Rainbow Ore Ingot",
+	description = S("Rainbow Ore Ingot"),
 	inventory_image = "rainbow_ore_ingot.png",
 })
 
@@ -36,7 +43,7 @@ minetest.register_craft({
 
 --Register Rainbow Pickaxe
 minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
-	description = "Rainbow Pickaxe",
+	description = S("Rainbow Pickaxe"),
 	inventory_image = "rainbow_ore_pickaxe.png",
 	tool_capabilities = {
 		full_punch_interval = 0.9,
@@ -62,7 +69,7 @@ minetest.register_craft({
 
 --Register Rainbow Axe
 minetest.register_tool("rainbow_ore:rainbow_ore_axe", {
-	description = "Rainbow Axe",
+	description = S("Rainbow Axe"),
 	inventory_image = "rainbow_ore_axe.png",
 	tool_capabilities = {
 		full_punch_interval = 0.9,
@@ -97,7 +104,7 @@ minetest.register_craft({
 
 --Register Rainbow shovel
 minetest.register_tool("rainbow_ore:rainbow_ore_shovel", {
-	description = "Rainbow Shovel",
+	description = S("Rainbow Shovel"),
 	inventory_image = "rainbow_ore_shovel.png",
 	wield_image = "rainbow_ore_shovel.png^[transformR90",
 	tool_capabilities = {
@@ -124,7 +131,7 @@ minetest.register_craft({
 
 --Register Rainbow sword
 minetest.register_tool("rainbow_ore:rainbow_ore_sword", {
-	description = "Rainbow Sword",
+	description = S("Rainbow Sword"),
 	inventory_image = "rainbow_ore_sword.png",
 	tool_capabilities = {
 		full_punch_interval = 0.7,

--- a/locale/rainbow_ore.es.tr
+++ b/locale/rainbow_ore.es.tr
@@ -1,0 +1,16 @@
+# textdomain:rainbow_ore
+
+# Translators: Jordan Irwin (AntumDeluge)
+
+
+Rainbow Ore=Mineral de Arcoíris
+Rainbow Ore Ingot=Lingote de Arcoíris
+Rainbow Pickaxe=Pico de Arcoíris
+Rainbow Axe=Hacha de Arcoíris
+Rainbow Shovel=Pala de Arcoíris
+Rainbow Sword=Espada de Arcoíris
+Rainbow Helmet=Casco de Arcoíris
+Rainbow Chestplate=Pechera de Arcoíris
+Rainbow Leggings=Esquinela de Arcoíris
+Rainbow Boots=Botas de Arcoíris
+Rainbow Shield=Escudo de Arcoíris

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -1,0 +1,16 @@
+# textdomain:rainbow_ore
+
+# Translators:
+
+
+Rainbow Ore=
+Rainbow Ore Ingot=
+Rainbow Pickaxe=
+Rainbow Axe=
+Rainbow Shovel=
+Rainbow Sword=
+Rainbow Helmet=
+Rainbow Chestplate=
+Rainbow Leggings=
+Rainbow Boots=
+Rainbow Shield=

--- a/mod.conf
+++ b/mod.conf
@@ -3,6 +3,6 @@ title = Rainbow Ore
 description = Rainbow materials & equipment.
 author = Robin Kuhn (KingSmarty)
 license = LGPL
-min_minetest_version = 0.4.16
+min_minetest_version = 5.0
 depends = default
 optional_depends = 3d_armor, shields

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,8 @@
+name = rainbow_ore
+title = Rainbow Ore
+description = Rainbow materials & equipment.
+author = Robin Kuhn (KingSmarty)
+license = LGPL
+min_minetest_version = 0.4.16
+depends = default
+optional_depends = 3d_armor, shields

--- a/rainbow_armor.lua
+++ b/rainbow_armor.lua
@@ -1,24 +1,28 @@
+
+local S = minetest.get_translator(rainbow_ore.modname)
+
+
 --Define Rainbow Armor
 minetest.register_tool("rainbow_ore:rainbow_ore_helmet", {
-	description = "Rainbow Helmet",
+	description = S("Rainbow Helmet"),
 	inventory_image = "rainbow_ore_helmet_inv.png",
 	groups = {armor_head=20, armor_heal=17, armor_use=40},
 	wear = 0,
 })
 minetest.register_tool("rainbow_ore:rainbow_ore_chestplate", {
-	description = "Rainbow Chestplate",
+	description = S("Rainbow Chestplate"),
 	inventory_image = "rainbow_ore_chestplate_inv.png",
 	groups = {armor_torso=25, armor_heal=17, armor_use=40},
 	wear = 0,
 })
 minetest.register_tool("rainbow_ore:rainbow_ore_leggings", {
-	description = "Rainbow Leggings",
+	description = S("Rainbow Leggings"),
 	inventory_image = "rainbow_ore_leggings_inv.png",
 	groups = {armor_legs=25, armor_heal=17, armor_use=40},
 	wear = 0,
 })
 minetest.register_tool("rainbow_ore:rainbow_ore_boots", {
-	description = "Rainbow Boots",
+	description = S("Rainbow Boots"),
 	inventory_image = "rainbow_ore_boots_inv.png",
 	groups = {armor_feet=20, armor_heal=17, armor_use=40},
 	wear = 0,

--- a/rainbow_shield.lua
+++ b/rainbow_shield.lua
@@ -1,6 +1,10 @@
+
+local S = minetest.get_translator(rainbow_ore.modname)
+
+
 --Define Rainbow shield
 minetest.register_tool("rainbow_ore:rainbow_ore_shield", {
-	description = "Rainbow Shield",
+	description = S("Rainbow Shield"),
 	inventory_image = "rainbow_ore_shield_inv.png",
 	groups = {armor_shield=20, armor_heal=17, armor_use=40, armor_fire=1},
 	wear = 0,


### PR DESCRIPTION
Adds:
- localization support using Minetest's built-in translator
- Spanish translation

Notes:
- breaks compatibility with Minetest version 0.4
- please check that details are correct in [`mod.conf`](https://github.com/AntumMT/mod-rainbow_ore/blob/cc7009b/mod.conf)

**Edit:** If you would like backwards compatibility, I can change it so that it works with Minetest 0.4 & restore the `depends.txt` file.