### PR TITLE
Make Default an Optional Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Crafting:
 
 Smelt "Rainbow Ore Block" --> "Rainbow Ingots"
 
-Tools are crafted as always but with "Rainbow Ingots" as material instead.
-
-Armor is crafted like Armor but with "Rainbow Ingots" as material instead.
-
-Shield are crafted like a shield but with "Rainbow Ingots" as material instead.
+- Tools:
+	- crafted as always but with "Rainbow Ingots" as material instead.
+	- if default mod is not available, "default:stick" is replaced with "rainbow_ore:rainbow_ore_ingot".
+- Armor:
+	- crafted like Armor but with "Rainbow Ingots" as material instead.
+- Shield:
+	- crafted like a shield but with "Rainbow Ingots" as material instead.
 
 You can craft Nyancat_rainbow blocks like any other "solid" blocks but with "Rainbow Ingots" as material instead.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Rainbow Ore
 ===========
 
-This mod features a new ore called "Rainbow Ore" (as if you guessed it :D) wich is pretty rare but also pretty powerful.
+This mod features a new ore called "Rainbow Ore" (as if you guessed it :D) which is pretty rare but also pretty powerful.
 
 License
 =======

--- a/init.lua
+++ b/init.lua
@@ -56,9 +56,13 @@ minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
 })
 
 
-local stick = "rainbow_ore:rainbow_ore_ingot"
-if minetest.registered_items["default:stick"] then
-	stick = "default:stick"
+local stick = minetest.settings:get("rainbow_ore.stick")
+if not stick then
+	if minetest.registered_items["default:stick"] then
+		stick = "default:stick"
+	else
+		stick = "rainbow_ore:rainbow_ore_ingot"
+	end
 end
 
 --Define Rainbow_Ore_Pickaxe crafting recipe

--- a/init.lua
+++ b/init.lua
@@ -172,13 +172,23 @@ minetest.register_craft({
 
 
 --Make Rainbow Ore spawn
-minetest.register_ore({
-	ore_type = "scatter",
-	ore = "rainbow_ore:rainbow_ore_block",
-	wherein = "default:stone",
-	clust_scarcity = 17*17*17,
-	clust_num_ores = 3,
-	clust_size = 3,
-	y_min = -31000,
-	y_max = -200,
-})
+local spawn_within = minetest.settings:get("rainbow_ore.spawn_within") or "default:stone"
+minetest.log("action", "[rainbow_ore] ore set to spawn within " .. spawn_within
+	.. ", this can be changed with rainbow_ore.spawn_within setting")
+
+minetest.register_on_mods_loaded(function()
+	if minetest.registered_nodes[spawn_within] then
+		minetest.register_ore({
+			ore_type = "scatter",
+			ore = "rainbow_ore:rainbow_ore_block",
+			wherein = spawn_within,
+			clust_scarcity = 17*17*17,
+			clust_num_ores = 3,
+			clust_size = 3,
+			y_min = -31000,
+			y_max = -200,
+		})
+	else
+		minetest.log("warning", "[rainbow_ore] " .. spawn_within .. " is not a registered node, rainbow ore will not spawn")
+	end
+end)

--- a/init.lua
+++ b/init.lua
@@ -56,13 +56,18 @@ minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
 })
 
 
+local stick = "rainbow_ore:rainbow_ore_ingot"
+if minetest.registered_items["default:stick"] then
+	stick = "default:stick"
+end
+
 --Define Rainbow_Ore_Pickaxe crafting recipe
 minetest.register_craft({
 	output = "rainbow_ore:rainbow_ore_pickaxe",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
-		{"", "default:stick", ""},
-		{"", "default:stick", ""}
+		{"", stick, ""},
+		{"", stick, ""}
 	}
 })
 
@@ -87,8 +92,8 @@ minetest.register_craft({
 	output = "rainbow_ore:rainbow_ore_axe",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", ""},
-		{"rainbow_ore:rainbow_ore_ingot", "default:stick", ""},
-		{"", "default:stick", ""}
+		{"rainbow_ore:rainbow_ore_ingot", stick, ""},
+		{"", stick, ""}
 	}
 })
 
@@ -96,8 +101,8 @@ minetest.register_craft({
 	output = "rainbow_ore:rainbow_ore_axe",
 	recipe = {
 		{"", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
-		{"", "default:stick", "rainbow_ore:rainbow_ore_ingot"},
-		{"", "default:stick", ""}
+		{"", stick, "rainbow_ore:rainbow_ore_ingot"},
+		{"", stick, ""}
 	}
 })
 
@@ -123,8 +128,8 @@ minetest.register_craft({
 	output = "rainbow_ore:rainbow_ore_shovel",
 	recipe = {
 		{"", "rainbow_ore:rainbow_ore_ingot", ""},
-		{"", "default:stick", ""},
-		{"", "default:stick", ""}
+		{"", stick, ""},
+		{"", stick, ""}
 	}
 })
 
@@ -150,7 +155,7 @@ minetest.register_craft({
 	recipe = {
 		{"", "rainbow_ore:rainbow_ore_ingot", ""},
 		{"", "rainbow_ore:rainbow_ore_ingot", ""},
-		{"", "default:stick", ""}
+		{"", stick, ""}
 	}
 })
 

--- a/mod.conf
+++ b/mod.conf
@@ -4,5 +4,4 @@ description = Rainbow materials & equipment.
 author = Robin Kuhn (KingSmarty)
 license = LGPL
 min_minetest_version = 5.0
-depends = default
-optional_depends = 3d_armor, shields
+optional_depends = default, 3d_armor, shields

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,4 @@
+
+# Determines node that will be replaced with "rainbow_ore:rainbow_ore_block"
+# when ore is spawned.
+rainbow_ore.spawn_within (Ore spawns within) string default:stone

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -6,4 +6,4 @@ rainbow_ore.stick (Stick item for rainbow tools recipes) string default:stick
 
 # Determines node that will be replaced with "rainbow_ore:rainbow_ore_block"
 # when ore is spawned.
-rainbow_ore.spawn_within (Ore spawns within) string default:stone
+rainbow_ore.spawn_within (Rainbow ore spawns within) string default:stone

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,9 @@
 
+# Determines the item used as "stick" component in rainbow tool craft recipes.
+# Default is "default:stick". If default mod is not available, then default
+# is "rainbow_ore:rainbow_ore_block".
+rainbow_ore.stick (Stick item for rainbow tools recipes) string default:stick
+
 # Determines node that will be replaced with "rainbow_ore:rainbow_ore_block"
 # when ore is spawned.
 rainbow_ore.spawn_within (Ore spawns within) string default:stone


### PR DESCRIPTION
- Removes hard dependency on `default`.
- If `default` mod not available, `default:stick` is replaced with `rainbow_ore:rainbow_ore_ingot` in recipes.
- Adds settings:
  - `rainbow_ore.stick`: customize "stick" item used in tool craft recipes
  - `rainbow_ore.spawn_within`: customize node that rainbow ore should spawn within (default: `default:stone`)