### PR TITLE
Replace "minetest" with "core"

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,23 +1,23 @@
 -- Rainbow_Ore Test Mod ----------- Copyright Robin Kuhn 2015
 
 rainbow_ore = {}
-rainbow_ore.modname = minetest.get_current_modname()
-rainbow_ore.modpath = minetest.get_modpath(rainbow_ore.modname)
+rainbow_ore.modname = core.get_current_modname()
+rainbow_ore.modpath = core.get_modpath(rainbow_ore.modname)
 
 --Check for mods
-if minetest.get_modpath("3d_armor") then
+if core.get_modpath("3d_armor") then
 dofile(rainbow_ore.modpath.."/rainbow_armor.lua")
 end
 
-if minetest.get_modpath("shields") then
+if core.get_modpath("shields") then
 dofile(rainbow_ore.modpath.."/rainbow_shield.lua")
 end
 
 
-local S = minetest.get_translator(rainbow_ore.modname)
+local S = core.get_translator(rainbow_ore.modname)
 
 -- Define Rainbow_Ore_Block node
-minetest.register_node("rainbow_ore:rainbow_ore_block", {
+core.register_node("rainbow_ore:rainbow_ore_block", {
 	description = S("Rainbow Ore"),
 	tiles = {"rainbow_ore_block.png"},
 	groups = {stone=2, cracky=3},
@@ -27,13 +27,13 @@ minetest.register_node("rainbow_ore:rainbow_ore_block", {
 
 
 --Define Rainbow_Ore_Ingot node
-minetest.register_craftitem("rainbow_ore:rainbow_ore_ingot", {
+core.register_craftitem("rainbow_ore:rainbow_ore_ingot", {
 	description = S("Rainbow Ore Ingot"),
 	inventory_image = "rainbow_ore_ingot.png",
 })
 
 --Define Rainbow_Ore Smelt Recipe
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	output = "rainbow_ore:rainbow_ore_ingot",
 	recipe = "rainbow_ore:rainbow_ore_block",
@@ -42,7 +42,7 @@ minetest.register_craft({
 
 
 --Register Rainbow Pickaxe
-minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
+core.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
 	description = S("Rainbow Pickaxe"),
 	inventory_image = "rainbow_ore_pickaxe.png",
 	tool_capabilities = {
@@ -56,9 +56,9 @@ minetest.register_tool("rainbow_ore:rainbow_ore_pickaxe", {
 })
 
 
-local stick = minetest.settings:get("rainbow_ore.stick")
+local stick = core.settings:get("rainbow_ore.stick")
 if not stick then
-	if minetest.registered_items["default:stick"] then
+	if core.registered_items["default:stick"] then
 		stick = "default:stick"
 	else
 		stick = "rainbow_ore:rainbow_ore_ingot"
@@ -66,7 +66,7 @@ if not stick then
 end
 
 --Define Rainbow_Ore_Pickaxe crafting recipe
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_pickaxe",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
@@ -77,7 +77,7 @@ minetest.register_craft({
 
 
 --Register Rainbow Axe
-minetest.register_tool("rainbow_ore:rainbow_ore_axe", {
+core.register_tool("rainbow_ore:rainbow_ore_axe", {
 	description = S("Rainbow Axe"),
 	inventory_image = "rainbow_ore_axe.png",
 	tool_capabilities = {
@@ -92,7 +92,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_axe", {
 
 
 --Define Rainbow Axe crafting recipe
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_axe",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", ""},
@@ -101,7 +101,7 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_axe",
 	recipe = {
 		{"", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
@@ -112,7 +112,7 @@ minetest.register_craft({
 
 
 --Register Rainbow shovel
-minetest.register_tool("rainbow_ore:rainbow_ore_shovel", {
+core.register_tool("rainbow_ore:rainbow_ore_shovel", {
 	description = S("Rainbow Shovel"),
 	inventory_image = "rainbow_ore_shovel.png",
 	wield_image = "rainbow_ore_shovel.png^[transformR90",
@@ -128,7 +128,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_shovel", {
 
 
 --Define Rainbow shovel crafting recipe
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_shovel",
 	recipe = {
 		{"", "rainbow_ore:rainbow_ore_ingot", ""},
@@ -139,7 +139,7 @@ minetest.register_craft({
 
 
 --Register Rainbow sword
-minetest.register_tool("rainbow_ore:rainbow_ore_sword", {
+core.register_tool("rainbow_ore:rainbow_ore_sword", {
 	description = S("Rainbow Sword"),
 	inventory_image = "rainbow_ore_sword.png",
 	tool_capabilities = {
@@ -154,7 +154,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_sword", {
 
 
 --Define Rainbow sword crafting recipe
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_sword",
 	recipe = {
 		{"", "rainbow_ore:rainbow_ore_ingot", ""},
@@ -165,7 +165,7 @@ minetest.register_craft({
 
 
 --Define Nyan Rainbow crafting recipe
-minetest.register_craft({
+core.register_craft({
 	output = "default:nyancat_rainbow",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
@@ -176,13 +176,13 @@ minetest.register_craft({
 
 
 --Make Rainbow Ore spawn
-local spawn_within = minetest.settings:get("rainbow_ore.spawn_within") or "default:stone"
-minetest.log("action", "[rainbow_ore] ore set to spawn within " .. spawn_within
+local spawn_within = core.settings:get("rainbow_ore.spawn_within") or "default:stone"
+core.log("action", "[rainbow_ore] ore set to spawn within " .. spawn_within
 	.. ", this can be changed with rainbow_ore.spawn_within setting")
 
-minetest.register_on_mods_loaded(function()
-	if minetest.registered_nodes[spawn_within] then
-		minetest.register_ore({
+core.register_on_mods_loaded(function()
+	if core.registered_nodes[spawn_within] then
+		core.register_ore({
 			ore_type = "scatter",
 			ore = "rainbow_ore:rainbow_ore_block",
 			wherein = spawn_within,
@@ -193,6 +193,6 @@ minetest.register_on_mods_loaded(function()
 			y_max = -200,
 		})
 	else
-		minetest.log("warning", "[rainbow_ore] " .. spawn_within .. " is not a registered node, rainbow ore will not spawn")
+		core.log("warning", "[rainbow_ore] " .. spawn_within .. " is not a registered node, rainbow ore will not spawn")
 	end
 end)

--- a/rainbow_armor.lua
+++ b/rainbow_armor.lua
@@ -1,36 +1,36 @@
 
-local S = minetest.get_translator(rainbow_ore.modname)
+local S = core.get_translator(rainbow_ore.modname)
 
 
 --Define Rainbow Armor
-minetest.register_tool("rainbow_ore:rainbow_ore_helmet", {
+core.register_tool("rainbow_ore:rainbow_ore_helmet", {
 	description = S("Rainbow Helmet"),
 	inventory_image = "rainbow_ore_helmet_inv.png",
 	groups = {armor_head=20, armor_heal=17, armor_use=40},
 	wear = 0,
 })
-minetest.register_tool("rainbow_ore:rainbow_ore_chestplate", {
+core.register_tool("rainbow_ore:rainbow_ore_chestplate", {
 	description = S("Rainbow Chestplate"),
 	inventory_image = "rainbow_ore_chestplate_inv.png",
 	groups = {armor_torso=25, armor_heal=17, armor_use=40},
 	wear = 0,
 })
-minetest.register_tool("rainbow_ore:rainbow_ore_leggings", {
+core.register_tool("rainbow_ore:rainbow_ore_leggings", {
 	description = S("Rainbow Leggings"),
 	inventory_image = "rainbow_ore_leggings_inv.png",
 	groups = {armor_legs=25, armor_heal=17, armor_use=40},
 	wear = 0,
 })
-minetest.register_tool("rainbow_ore:rainbow_ore_boots", {
+core.register_tool("rainbow_ore:rainbow_ore_boots", {
 	description = S("Rainbow Boots"),
 	inventory_image = "rainbow_ore_boots_inv.png",
 	groups = {armor_feet=20, armor_heal=17, armor_use=40},
 	wear = 0,
 })
- 
- 
+
+
 --Define Rainbow Armor crafting recipe
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_helmet",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
@@ -38,7 +38,7 @@ minetest.register_craft({
 		{"", "", ""},
 	},
 })
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_chestplate",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "", "rainbow_ore:rainbow_ore_ingot"},
@@ -46,7 +46,7 @@ minetest.register_craft({
 		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
 	},
 })
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_leggings",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},
@@ -54,7 +54,7 @@ minetest.register_craft({
 		{"rainbow_ore:rainbow_ore_ingot", "", "rainbow_ore:rainbow_ore_ingot"},
 	},
 })
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_boots",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "", "rainbow_ore:rainbow_ore_ingot"},

--- a/rainbow_shield.lua
+++ b/rainbow_shield.lua
@@ -1,9 +1,9 @@
 
-local S = minetest.get_translator(rainbow_ore.modname)
+local S = core.get_translator(rainbow_ore.modname)
 
 
 --Define Rainbow shield
-minetest.register_tool("rainbow_ore:rainbow_ore_shield", {
+core.register_tool("rainbow_ore:rainbow_ore_shield", {
 	description = S("Rainbow Shield"),
 	inventory_image = "rainbow_ore_shield_inv.png",
 	groups = {armor_shield=20, armor_heal=17, armor_use=40, armor_fire=1},
@@ -12,7 +12,7 @@ minetest.register_tool("rainbow_ore:rainbow_ore_shield", {
 
 
 --Define Rainbow shield crafting recipe
-minetest.register_craft({
+core.register_craft({
 	output = "rainbow_ore:rainbow_ore_shield",
 	recipe = {
 		{"rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot", "rainbow_ore:rainbow_ore_ingot"},


### PR DESCRIPTION
Replaces all references to deprecated `minetest` namespace with `core`.